### PR TITLE
fix: Resolve valid $refs

### DIFF
--- a/src/__tests__/resolver.spec.ts
+++ b/src/__tests__/resolver.spec.ts
@@ -160,6 +160,31 @@ describe('resolver', () => {
       expect(resolved.result.hello).toBe('world');
     });
 
+    test('should only resolve valid $refs', async () => {
+      const source = {
+        hello: {
+          $ref: {
+            foo: 'bear',
+          },
+        },
+        word: 'world',
+      };
+
+      const resolver = new Resolver();
+      let resolved = await resolver.resolve(source);
+      expect(resolved.result).toEqual(source);
+
+      // @ts-ignore
+      source.hello.$ref = true;
+      resolved = await resolver.resolve(source);
+      expect(resolved.result).toEqual(source);
+
+      // @ts-ignore
+      source.hello.$ref = 1;
+      resolved = await resolver.resolve(source);
+      expect(resolved.result).toEqual(source);
+    });
+
     test('should support not resolving pointers', async () => {
       const source = {
         hello: {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -16,7 +16,6 @@ let resolveRunnerCount = 0;
 export const defaultGetRef = (key: string, val: any) => {
   if (val && typeof val === 'object' && val.$ref) {
     const { $ref } = val;
-
     if (typeof $ref === 'string') return val.$ref;
   }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -15,7 +15,9 @@ let resolveRunnerCount = 0;
 
 export const defaultGetRef = (key: string, val: any) => {
   if (val && typeof val === 'object' && val.$ref) {
-    return val.$ref;
+    const { $ref } = val;
+
+    if (typeof $ref === 'string' && URI.parse($ref).toString() !== '') return val.$ref;
   }
 
   return;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -14,11 +14,7 @@ const memoize = require('fast-memoize');
 let resolveRunnerCount = 0;
 
 export const defaultGetRef = (key: string, val: any) => {
-  if (val && typeof val === 'object' && val.$ref) {
-    const { $ref } = val;
-    if (typeof $ref === 'string') return val.$ref;
-  }
-
+  if (val && typeof val === 'object' && typeof val.$ref === 'string') return val.$ref;
   return;
 };
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -17,7 +17,7 @@ export const defaultGetRef = (key: string, val: any) => {
   if (val && typeof val === 'object' && val.$ref) {
     const { $ref } = val;
 
-    if (typeof $ref === 'string' && URI.parse($ref).toString() !== '') return val.$ref;
+    if (typeof $ref === 'string') return val.$ref;
   }
 
   return;


### PR DESCRIPTION
[SL-1382](https://stoplightio.atlassian.net/browse/SL-1382)

@marbemac my only concern with this we let users overwrite the getRef function? Should we put this check after we call the getRef function and require that a string is returned from it?