### PR TITLE
fix(deps): include tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "fast-memoize": "^2.5.1",
     "immer": "^3.2.0",
     "lodash": "^4.17.15",
+    "tslib": "^1.10.0",
     "urijs": "~1.19.1",
     "vscode-uri": "^2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8030,7 +8030,7 @@ tslib@1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
`tslib` is required for json-res-resolver to work, but it's not listed among dependencies.

Reference: https://github.com/openapi-community/json-schema-to-openapi-schema/pull/3#event-2691504158