### PR TITLE
feat: graphlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "test.watch": "yarn test --watch"
   },
   "dependencies": {
+    "@dagrejs/graphlib": "^2.1.4",
     "@stoplight/json": "^3.1.0",
     "@stoplight/types": "^11.0.0",
-    "dependency-graph": "~0.8.0",
     "fast-memoize": "^2.5.1",
     "immer": "^3.2.0",
     "lodash": "^4.17.15",
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@stoplight/scripts": "5.x.x",
+    "@types/graphlib": "^2.1.5",
     "@types/jest": "24.0.18",
     "@types/lodash": "4.14.141",
     "@types/urijs": "1.x.x",

--- a/src/__tests__/resolver.spec.ts
+++ b/src/__tests__/resolver.spec.ts
@@ -6,6 +6,7 @@ import { Cache } from '../cache';
 import { Resolver } from '../resolver';
 import { defaultGetRef, ResolveRunner } from '../runner';
 import * as Types from '../types';
+import { getDependenciesOf } from '../utils';
 import httpMocks from './fixtures/http-mocks';
 import resolvedResults from './fixtures/resolved';
 
@@ -2106,7 +2107,7 @@ describe('resolver', () => {
       const resolver = new Resolver();
       const { graph } = await resolver.resolve(data);
 
-      expect(graph.dependenciesOf('root')).toMatchSnapshot();
+      expect(getDependenciesOf(graph, 'root')).toMatchSnapshot();
     });
 
     // ./a#/foo -> ./b#bar -> ./a#/xxx -> ./c -> ./b#/zzz
@@ -2124,7 +2125,7 @@ describe('resolver', () => {
         baseUri,
       });
 
-      expect(graph.dependenciesOf[baseUri]).toMatchSnapshot();
+      expect(getDependenciesOf(graph, baseUri)).toMatchSnapshot();
     });
 
     test('circular refs', async () => {
@@ -2143,7 +2144,7 @@ describe('resolver', () => {
       const resolver = new Resolver();
       const { graph } = await resolver.resolve(source);
 
-      expect(graph.dependenciesOf('root')).toMatchSnapshot();
+      expect(getDependenciesOf(graph, 'root')).toMatchSnapshot();
     });
 
     test('indirect circular refs', async () => {
@@ -2190,7 +2191,7 @@ describe('resolver', () => {
 
       const { graph } = await resolver.resolve(source);
 
-      expect(graph.dependenciesOf('root')).toMatchSnapshot();
+      expect(getDependenciesOf(graph, 'root')).toMatchSnapshot();
     });
   });
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,4 @@
-import { DepGraph } from 'dependency-graph';
+import { Graph } from '@dagrejs/graphlib';
 
 import { Cache } from './cache';
 import { ResolveRunner } from './runner';
@@ -37,7 +37,7 @@ export class Resolver {
   }
 
   public resolve(source: any, opts: Types.IResolveOpts = {}): Promise<Types.IResolveResult> {
-    const graph = new DepGraph<any>({ circular: true });
+    const graph = new Graph({ directed: true });
     const runner = new ResolveRunner(source, graph, {
       uriCache: this.uriCache,
       resolvers: this.resolvers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { Dictionary, Segment } from '@stoplight/types';
-import { DepGraph } from 'dependency-graph';
+import { Segment } from '@stoplight/types';
+import { Graph } from 'graphlib';
 
 /**
  * The following interfaces are the primary interaction points for json-ref-resolver.
@@ -113,7 +113,7 @@ export interface IResolveResult {
    * A graph of every single reference in source.
    *
    */
-  graph: DepGraph<IGraphNodeData>;
+  graph: Graph;
 
   /** Any errors that occured during the resolution process. */
   errors: IResolveError[];
@@ -222,29 +222,6 @@ export interface IRefHandlerOpts {
   parentPointer: string;
 }
 
-export interface IGraphNodeData {
-  /**
-   * A map of the root URI string to the property paths that reference this node.
-   *
-   * Example:
-   *
-   * ```json
-   * {
-   *   "root": [
-   *     "#/properties/name",
-   *     "#/properties/user/properties/name"
-   *   ],
-   *   "file:///api.json/#models/card": [
-   *     "#/properties/name"
-   *   ]
-   * }
-   * ```
-   */
-  propertyPaths: Dictionary<string[]>;
-
-  data: any;
-}
-
 export interface IResolveRunner {
   id: number;
   source: any;
@@ -254,7 +231,7 @@ export interface IResolveRunner {
   depth: number;
   baseUri: uri.URI;
 
-  graph: DepGraph<IGraphNodeData>;
+  graph: Graph;
   root: string;
 
   atMaxUriDepth: () => boolean;
@@ -273,8 +250,8 @@ export interface IResolveRunnerOpts extends IResolveOpts {
 
 export interface ICrawler {
   jsonPointer?: string;
-  pointerGraph: DepGraph<string>;
-  pointerStemGraph: DepGraph<string>;
+  pointerGraph: Graph;
+  pointerStemGraph: Graph;
   resolvers: Array<Promise<IUriResult>>;
   computeGraph: (target: any, parentPath: string[], parentPointer: string, pointerStack?: string[]) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Segment } from '@stoplight/types';
+import { Dictionary, Segment } from '@stoplight/types';
 import { DepGraph } from 'dependency-graph';
 
 /**
@@ -113,7 +113,7 @@ export interface IResolveResult {
    * A graph of every single reference in source.
    *
    */
-  graph: DepGraph<any>;
+  graph: DepGraph<IGraphNodeData>;
 
   /** Any errors that occured during the resolution process. */
   errors: IResolveError[];
@@ -222,6 +222,29 @@ export interface IRefHandlerOpts {
   parentPointer: string;
 }
 
+export interface IGraphNodeData {
+  /**
+   * A map of the root URI string to the property paths that reference this node.
+   *
+   * Example:
+   *
+   * ```json
+   * {
+   *   "root": [
+   *     "#/properties/name",
+   *     "#/properties/user/properties/name"
+   *   ],
+   *   "file:///api.json/#models/card": [
+   *     "#/properties/name"
+   *   ]
+   * }
+   * ```
+   */
+  propertyPaths: Dictionary<string[]>;
+
+  data: any;
+}
+
 export interface IResolveRunner {
   id: number;
   source: any;
@@ -231,7 +254,7 @@ export interface IResolveRunner {
   depth: number;
   baseUri: uri.URI;
 
-  graph: DepGraph<any>;
+  graph: DepGraph<IGraphNodeData>;
   root: string;
 
   atMaxUriDepth: () => boolean;

--- a/src/types/@dagrejs/graphlib.d.ts
+++ b/src/types/@dagrejs/graphlib.d.ts
@@ -1,0 +1,2 @@
+// Typings workaround described here: https://github.com/dagrejs/graphlib/issues/84
+export * from 'graphlib';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { alg, Graph } from '@dagrejs/graphlib';
+import { initial, tail } from 'lodash';
+
 const replace = (str: string, find: string, repl: string): string => {
   // modified from http://jsperf.com/javascript-replace-all/10
   const orig = str.toString();
@@ -39,3 +42,13 @@ export const uriToJSONPointer = (uri: uri.URI): string => {
 export const uriIsJSONPointer = (ref: uri.URI): boolean => {
   return ref.toString().slice(0, 2) === '#/';
 };
+
+/** @hidden */
+export function getDependenciesOf(graph: Graph, nodeId: string) {
+  return (graph.outEdges(nodeId) || []).map(edge => edge.w);
+}
+
+/** @hidden */
+export function getDependantsOf(graph: Graph, nodeId: string) {
+  return (graph.inEdges(nodeId) || []).map(edge => edge.v);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
   "include": ["."],
 
   "compilerOptions": {
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "baseUrl": ".",
+    "paths": { "*": ["src/types/*"] }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,13 @@
   dependencies:
     find-up "^2.1.0"
 
+"@dagrejs/graphlib@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.1.4.tgz#86c70e4f073844a2f4ada254c8c7b88a6bdacdb1"
+  integrity sha512-QCg9sL4uhjn468FDEsb/S9hS2xUZSrv/+dApb1Ze5VKO96pTXKNJZ6MGhIpgWkc1TVhbVGH9/7rq/Mf8/jWicw==
+  dependencies:
+    lodash "^4.11.1"
+
 "@iamstarkov/listr-update-renderer@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz#d7c48092a2dcf90fd672b6c8b458649cb350c77e"
@@ -872,6 +879,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/graphlib@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/graphlib/-/graphlib-2.1.5.tgz#ed0435f99c91531aaa93086529804bbe3cd42c3b"
+  integrity sha512-ZNQa42alTPUbBZ6c2einxsHmnz/YX/CqB8a1P5QTmbBqr9Q4x01fqPdXwBmMBQOm67fg9rACpidyIaCtvg8RVQ==
 
 "@types/handlebars@^4.0.38":
   version "4.1.0"
@@ -2326,11 +2338,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-dependency-graph@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.0.tgz#2da2d35ed852ecc24a5d6c17788ba57c3708755b"
-  integrity sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -5010,7 +5017,7 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
Switches from using [dependency-graph](https://github.com/jriecken/dependency-graph) to [@dagrejs/graphlib](https://github.com/dagrejs/graphlib)

**TODO**
- 7 failing tests in `src/__tests__/resolver.spec.ts` all involving circular refs
  - resolver › print tree › indirect circular refs
  - resolver › print tree › should resolve http relative paths + back pointing uri refs
  - resolver › circular handling › should handle indirect circular pointer refs
  - resolver › resolve › should support chained jsonPointers + partial resolution
  - resolver › fixtures › stress test
  - resolver › fixtures › circularlocalref.json
  - resolver › fixtures › apideeplink.simple.json

![image](https://user-images.githubusercontent.com/7423098/66598035-c8869c00-eb65-11e9-8f5d-9dce4ecb5cd1.png)

- [ ] Set the property paths for each edge [here](https://github.com/stoplightio/json-ref-resolver/blob/cd7c730d504f3d40ecaeaa2eb2aa02253373e567/src/crawler.ts#L153) and [here](https://github.com/stoplightio/json-ref-resolver/blob/cd7c730d504f3d40ecaeaa2eb2aa02253373e567/src/crawler.ts#L179)
- [ ] graphlib has support for [multigraphs](https://github.com/dagrejs/graphlib/wiki/API-Reference#multigraphs) so we might be able to combine the pointer and pointerStem graphs?
- [ ] graphlib has a nice utility for surfacing circular deps: https://github.com/dagrejs/graphlib/wiki/API-Reference#alg-find-cycles