### PR TITLE
docs: link to readers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How to Contribute
+
+First of all, thanks for considering contributing! ✨ It's people like you that make open-source tools awesome. 💖
+
+At Stoplight, we want contributing to any of our tools to be an enjoyable and educational experience for everyone. Contributions go beyond commits in pull requests. We are excited to receive contributions in the form of feature ideas, pull requests, triaging issues, reviewing pull requests, implementations in your own projects, blog posts, talks referencing the project, tweets, and much more.
+
+## Stoplight Community Code of Conduct
+
+The Stoplight Community is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all community participants, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, religion (or lack thereof), or other identity markers. 
+
+Our Code of Conduct exists because of that dedication, and we do not tolerate harassment in any form. See our reporting guidelines [here](https://github.com/stoplightio/code-of-conduct/blob/master/incident-reporting.md). Our full Code of Conduct can be found at this [link](https://github.com/stoplightio/code-of-conduct/blob/master/long-form-code-of-conduct.md#long-form-code-of-conduct).
+
+## Development
+
+Yarn is a package manager for your code, similar to npm. While you can use npm to use json-ref-resolver in your own project, we use yarn for development.
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your computer.
+2. Install yarn: `npm install -g yarn`
+3. Install deps: `yarn`.
+4. Make your changes.
+5. Run tests: `yarn test.prod`.
+6. Stage relevant files to git.
+7. Commit: `yarn commit`. _NOTE: Commits that don't follow the [conventional](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional) format will be rejected. `yarn commit` creates this format for you, or you can put it together manually and then do a regular `git commit`._
+8. Push: `git push`.
+9. Open PR targeting the `master` branch.
+
+If this is your first Pull Request on GitHub, here's some [help](https://egghead.io/lessons/javascript-how-to-create-a-pull-request-on-github). 
+
+> We try to respond to all pull requests and issues within 7 days. We welcome feedback from everyone involved in the project in open pull requests. 
+
+If you spot any problems, file an [issue on GitHub](https://github.com/stoplightio/json-ref-resolver/issues).

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# JSON Ref Resolver
+# JSON Ref Resolver 
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/0b1d841cc2445e29ef50/maintainability)](https://codeclimate.com/github/stoplightio/json-ref-resolver/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0b1d841cc2445e29ef50/test_coverage)](https://codeclimate.com/github/stoplightio/json-ref-resolver/test_coverage)
+[![Buy us a tree](https://img.shields.io/badge/Buy%20us%20a%20tree-%F0%9F%8C%B3-lightgreen)](https://offset.earth/stoplightinc)
+[![CircleCI](https://circleci.com/gh/stoplightio/json-ref-resolver.svg?style=svg)](https://circleci.com/gh/stoplightio/json-ref-resolver)
 
-Dereference $ref values in JSON Schema, OpenAPI (Swagger), and any other objects with $ref values inside of them.
+Follow `$ref` values in JSON Schema, OpenAPI (formerly known as Swagger), and any other objects with `$ref` values inside of them.
 
 - View the changelog: [Releases](https://github.com/stoplightio/json-ref-resolver/releases)
 
-### Features
+## Features
 
 - **Performant**: Hot paths are memoized, remote URIs are resolved concurrently, and the minimum surface area is crawled and resolved.
 - **Caching**: Results from remote URIs are cached.
 - **Immutable**: The original object is not changed, and structural sharing is used to only change relevant bits. [example test](src/__tests__/resolver.spec.ts#L182)
 - **Reference equality:** $refs to the same location will resolve to the same object in memory. [example test](src/__tests__/resolver.spec.ts#L329)
-- **Flexible:** Bring your own resolvers for `http://`, `file://`, `mongo://`, `custom://`... etc.
+- **Flexible:** Bring your own readers for `http://`, `file://`, `mongo://`, `custom://`... etc, or use [one of ours][json-ref-readers].
 - **Cross Platform:** Supports POSIX and Windows style file paths.
 - **Reliable:** Well tested to handle all sorts of circular reference edge cases.
 
-### Installation
+## Installation
 
 Supported in modern browsers and node.
 
 ```bash
-# latest stable
 yarn add @stoplight/json-ref-resolver
 ```
 
-### Usage
+## Usage
 
 All relevant types and options can be found in [src/types.ts](./src/types.ts).
 
@@ -62,7 +62,7 @@ const resolver = new Resolver(globalOpts);
 const resolved = await resolver.resolve(sourceObj, resolveOpts);
 ```
 
-#### Example: Basic Inline Dereferencing
+### Example: Basic Inline Dereferencing
 
 By default, only inline references will be dereferenced.
 
@@ -94,7 +94,7 @@ expect(resolved.result).toEqual({
 });
 ```
 
-#### Example: Dereference a Subset of the Source
+### Example: Dereference a Subset of the Source
 
 This will dereference the minimal number of references needed for the given target, and return the target.
 
@@ -140,7 +140,7 @@ expect(resolved.result).toEqual({
 });
 ```
 
-#### Example: Dereferencing Remote References with Resolvers
+### Example: Dereferencing Remote References with Resolvers
 
 By default only inline references (those that point to values inside of the original object) are dereferenced.
 
@@ -204,7 +204,7 @@ expect(resolved.result).toEqual({
 });
 ```
 
-#### Example: Dereferencing Relative Remote References with the baseUri Option
+### Example: Dereferencing Relative Remote References with the baseUri Option
 
 If there are relative remote references (for example, a relative file path `../model.json`), then the location of the source
 data must be specified via the `baseUri` option. Relative references will be dereferenced against this baseUri.
@@ -244,16 +244,12 @@ expect(resolved.result).toEqual({
 });
 ```
 
-In the above example, the user \$ref will resolve to `/models/user.json`, because `../models/user.json` is resolved against the baseUri of the current document (which was indicated at `/specs/api.json`). Relative references will not work if the source document has no baseUri set.
+In the above example, the user `$ref` will resolve to `/models/user.json`, because `../models/user.json` is resolved against the `baseUri` of the current document (which was indicated at `/specs/api.json`). Relative references will not work if the source document has no baseUri set.
 
-### Contributing
+This is a simplistic example of a reader. You can create your own, but we have built some [readers][json-ref-readers] which you might find useful.
 
-1. Clone repo.
-2. Create / checkout `feature/{name}`, `chore/{name}`, or `fix/{name}` branch.
-3. Install deps: `yarn`.
-4. Make your changes.
-5. Run tests: `yarn test.prod`.
-6. Stage relevant files to git.
-7. Commit: `yarn commit`. _NOTE: Commits that don't follow the [conventional](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional) format will be rejected. `yarn commit` creates this format for you, or you can put it together manually and then do a regular `git commit`._
-8. Push: `git push`.
-9. Open PR targeting the `develop` branch.
+## Contributing
+
+If you are interested in contributing to Spectral itself, check out our [contributing docs](CONTRIBUTING.md) to get started.
+
+[json-ref-readers]: https://github.com/stoplightio/json-ref-readers/


### PR DESCRIPTION
Now we've got json-ref-readers ready for prime time, let's link to it from our docs here. 

In general this repo should be treated a bit more like an open source project now, as its super useful to a lot of people, not just a dependency in our codebase which happens to be public :D 