### PR TITLE
perf: uriToJSONPointer avoids returning hash when redundant

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const addToJSONPointer = (pointer: string, part: string): string => {
 
 /** @hidden */
 export const uriToJSONPointer = (uri: uri.URI): string => {
-  return uri.fragment() ? `#${uri.fragment()}` : '#';
+  return uri.fragment() !== '' ? `#${uri.fragment()}` : uri.href() === '' ? '#' : '';
 };
 
 /** @hidden */


### PR DESCRIPTION
Addresses the following performance issue https://github.com/stoplightio/studio-internal/issues/1596