### PR TITLE
build(circleci): run against Node 8, 10, 12 and latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,33 @@
-version: 2
+version: 2.1
+
+commands:
+  cached-dependencies:
+    steps:
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+
+  install_and_test:
+    description: >-
+      Install everything required to run the test suite, then run it.
+    steps:
+      - cached-dependencies
+      - run: yarn test.prod
 
 jobs:
-  test_node_8:
+  # https://nodejs.org/en/about/releases/
+  test_node_lts:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:
@@ -11,20 +35,40 @@ jobs:
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
-      - run: yarn
       - run:
           name: cc-before
           command: |
             ./cc-test-reporter before-build
-      - run: yarn test.prod
+      - install_and_test
       - run:
           name: cc-after
           command: |
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
 
+  test_node_dubnium:
+    docker:
+      - image: circleci/node:dubnium
+    steps:
+      - checkout
+      - install_and_test
+
+  test_node_carbon:
+    docker:
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - install_and_test
+
+  test_node_latest:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - install_and_test
+
   release:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
     steps:
       - checkout
       - run: yarn
@@ -35,10 +79,16 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-      - test_node_8
+      - test_node_lts
+      - test_node_carbon
+      - test_node_dubnium
+      - test_node_latest
       - release:
           filters:
             branches:
               only: master
           requires:
-            - test_node_8
+            - test_node_lts
+            - test_node_carbon
+            - test_node_dubnium
+            - test_node_latest


### PR DESCRIPTION
carbon = latest 8v LTS
bubnium = latest 10v LTS
lts= latest 12 LTS
latest is the latest version :wink:

Some context: https://github.com/stoplightio/json-ref-resolver/pull/168