### PR TITLE
fix: use lodash dep instead of lodash.set

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fast-memoize": "^2.5.2",
     "immer": "^9.0.6",
     "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2",
+    "lodash": "^4.17.21",
     "tslib": "^2.3.1",
     "urijs": "^1.19.6"
   },
@@ -60,7 +60,7 @@
     "@stoplight/scripts": "^5",
     "@types/jest": "^24.9.0",
     "@types/lodash.get": "^4.4.6",
-    "@types/lodash.set": "^4.3.6",
+    "@types/lodash": "^4.14.178",
     "benchmark": "^2.1",
     "jest": "^24.9",
     "ts-jest": "^24.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "dependency-graph": "~0.11.0",
     "fast-memoize": "^2.5.2",
     "immer": "^9.0.6",
-    "lodash.get": "^4.4.2",
     "lodash": "^4.17.21",
     "tslib": "^2.3.1",
     "urijs": "^1.19.6"
@@ -59,7 +58,6 @@
   "devDependencies": {
     "@stoplight/scripts": "^5",
     "@types/jest": "^24.9.0",
-    "@types/lodash.get": "^4.4.6",
     "@types/lodash": "^4.14.178",
     "benchmark": "^2.1",
     "jest": "^24.9",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,7 +1,7 @@
 import { pointerToPath } from '@stoplight/json';
 import { Optional } from '@stoplight/types';
 import { DepGraph } from 'dependency-graph';
-import get = require('lodash.get');
+import get = require('lodash/get');
 
 import * as Types from './types';
 import * as Utils from './utils';

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,8 +2,8 @@ import { pathToPointer, pointerToPath, startsWith, trimStart } from '@stoplight/
 import { dirname, join, stripRoot, toFSPath } from '@stoplight/path';
 import { DepGraph } from 'dependency-graph';
 import produce, { original } from 'immer';
+import lod = require('lodash');
 import get = require('lodash.get');
-import set = require('lodash.set');
 import * as URI from 'urijs';
 import { ExtendedURI } from './uri';
 
@@ -197,7 +197,7 @@ export class ResolveRunner implements Types.IResolveRunner {
             if (!resolvedTargetPath.length) {
               return r.resolved.result;
             } else {
-              set(draft, resolvedTargetPath, r.resolved.result);
+              lod.set(draft, resolvedTargetPath, r.resolved.result);
 
               this._setGraphNodeData(String(r.uri), r.resolved.result);
             }
@@ -246,7 +246,7 @@ export class ResolveRunner implements Types.IResolveRunner {
                 this._setGraphNodeEdge(this.root, pathToPointer(dependantPath), pathToPointer(pointerPath));
 
                 if (val !== void 0) {
-                  set(draft, dependantPath, val);
+                  lod.set(draft, dependantPath, val);
 
                   this._setGraphNodeData(pathToPointer(pointerPath), val);
                 } else {
@@ -507,7 +507,7 @@ export class ResolveRunner implements Types.IResolveRunner {
                 : error.path;
 
               if (errorPathInResult && errorPathInResult.length) {
-                set(lookupResult.resolved.result, errorPathInResult, val);
+                lod.set(lookupResult.resolved.result, errorPathInResult, val);
               } else if (lookupResult.resolved.result) {
                 lookupResult.resolved.result = val;
               }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,8 +2,8 @@ import { pathToPointer, pointerToPath, startsWith, trimStart } from '@stoplight/
 import { dirname, join, stripRoot, toFSPath } from '@stoplight/path';
 import { DepGraph } from 'dependency-graph';
 import produce, { original } from 'immer';
-import lod = require('lodash');
-import get = require('lodash.get');
+import get = require('lodash/get');
+import set = require('lodash/set');
 import * as URI from 'urijs';
 import { ExtendedURI } from './uri';
 
@@ -197,7 +197,7 @@ export class ResolveRunner implements Types.IResolveRunner {
             if (!resolvedTargetPath.length) {
               return r.resolved.result;
             } else {
-              lod.set(draft, resolvedTargetPath, r.resolved.result);
+              set(draft, resolvedTargetPath, r.resolved.result);
 
               this._setGraphNodeData(String(r.uri), r.resolved.result);
             }
@@ -246,7 +246,7 @@ export class ResolveRunner implements Types.IResolveRunner {
                 this._setGraphNodeEdge(this.root, pathToPointer(dependantPath), pathToPointer(pointerPath));
 
                 if (val !== void 0) {
-                  lod.set(draft, dependantPath, val);
+                  set(draft, dependantPath, val);
 
                   this._setGraphNodeData(pathToPointer(pointerPath), val);
                 } else {
@@ -507,7 +507,7 @@ export class ResolveRunner implements Types.IResolveRunner {
                 : error.path;
 
               if (errorPathInResult && errorPathInResult.length) {
-                lod.set(lookupResult.resolved.result, errorPathInResult, val);
+                set(lookupResult.resolved.result, errorPathInResult, val);
               } else if (lookupResult.resolved.result) {
                 lookupResult.resolved.result = val;
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,17 +939,15 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.set@^4.3.6":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.6.tgz#33e635c2323f855359225df6a5c8c6f1f1908264"
-  integrity sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*", "@types/lodash@^4.14.110":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
+"@types/lodash@^4.14.178":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
 "@types/marked@^0.4.0":
   version "0.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,14 +932,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/lodash.get@^4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
-  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.110":
+"@types/lodash@^4.14.110":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==


### PR DESCRIPTION
`set` from [lodash](https://www.npmjs.com/package/lodash) should be used instead of [lodash.set](https://www.npmjs.com/package/lodash.set) because it is outdated and has an unfixed prototype pollution vulnerability: https://security.snyk.io/vuln/SNYK-JS-LODASHSET-1320032