### PR TITLE
build: bump urijs version to avoid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     "@stoplight/json": "^3.17.0",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^12.3.0",
-    "@types/urijs": "^1.19.16",
+    "@types/urijs": "^1.19.19",
     "dependency-graph": "~0.11.0",
     "fast-memoize": "^2.5.2",
     "immer": "^9.0.6",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "tslib": "^2.3.1",
-    "urijs": "^1.19.6"
+    "urijs": "^1.19.10"
   },
   "devDependencies": {
     "@stoplight/scripts": "^5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,10 +989,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/urijs@^1.19.16":
-  version "1.19.16"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.16.tgz#156658c47438fa867db5dce4d2949fe1ca0878e2"
-  integrity sha512-WgxqcUSEYijGnNWHSln/uqay+AywS3mEhLC+d2PwLsru2fLeMblvxP67Y/SCfB2Pxe+dX/zbIoNNzXY+VKOtNA==
+"@types/urijs@^1.19.19":
+  version "1.19.19"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
+  integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -8484,10 +8484,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.19.6:
-  version "1.19.7"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.7.tgz#4f594e59113928fea63c00ce688fb395b1168ab9"
-  integrity sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA==
+urijs@^1.19.10:
+  version "1.19.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
+  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
See: https://security.snyk.io/vuln/SNYK-JS-URIJS-2415026

urijs needs to be bumped to 1.19.9 or higher