### PR TITLE
fix: urijs treats leading whitespaces differently

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
   "dependencies": {
     "@stoplight/json": "^3.17.0",
     "@stoplight/path": "^1.3.2",
-    "@stoplight/types": "^12.3.0",
+    "@stoplight/types": "^12.3.0 || ^13.0.0",
     "@types/urijs": "^1.19.19",
     "dependency-graph": "~0.11.0",
     "fast-memoize": "^2.5.2",
     "immer": "^9.0.6",
     "lodash": "^4.17.21",
     "tslib": "^2.3.1",
-    "urijs": "^1.19.10"
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "@stoplight/scripts": "^5",

--- a/src/__tests__/resolver.spec.ts
+++ b/src/__tests__/resolver.spec.ts
@@ -209,7 +209,7 @@ describe('resolver', () => {
         },
         {
           code: 'RESOLVE_URI',
-          message: "Error: ENOENT: no such file or directory, open ' '",
+          message: expect.stringMatching(/^Error: ENOENT: no such file or directory, open/),
           path: ['whitespace'],
           pointerStack: [],
           uriStack: [],

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -1,8 +1,10 @@
 import * as BaseURI from 'urijs';
 
 export class ExtendedURI extends BaseURI {
-  constructor(private readonly _value: string) {
+  private readonly _value: string;
+  constructor(_value: string) {
     super(_value);
+    this._value = _value.trim();
   }
 
   public get length() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,10 +826,10 @@
     tslib "1.9.3"
     typedoc "0.14.2"
 
-"@stoplight/types@^12.3.0":
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.3.0.tgz#ac71d295319f26abb279e3d89d1c1774857d20b4"
-  integrity sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==
+"@stoplight/types@^12.3.0", "@stoplight/types@^12.3.0 || ^13.0.0":
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.5.0.tgz#ebbeeb8c874de30e4cd9a1a2a6c8d6062c155da0"
+  integrity sha512-dwqYcDrGmEyUv5TWrDam5TGOxU72ufyQ7hnOIIDdmW5ezOwZaBFoR5XQ9AsH49w7wgvOqB2Bmo799pJPWnpCbg==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
@@ -8475,10 +8475,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.19.10:
-  version "1.19.10"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
-  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Needed in order to release json-ref-resolver and close https://github.com/stoplightio/spectral/issues/2017

Regressed in https://github.com/stoplightio/json-ref-resolver/commit/265ae19abf64933d8be9733530fcf18f38be145b
Unfortunately, the CI checks didn't run on that PR, so we couldn't catch that regression.
Luckily they were executed on the master branch, so no new release has been made.