### PR TITLE
build: release using Node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ jobs:
 
   release:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:12
     steps:
       - checkout
-      - run: yarn
+      - run: yarn --ignore-engines
       - run: yarn build
       - run: yarn release
 


### PR DESCRIPTION
we have an outdated version of semantic-release/npm that does not support > Node 12.
We could update @stoplight/scripts, but that could potentially break the release process so it's safer to stick around with what we have